### PR TITLE
luci: Fix read custom.d

### DIFF
--- a/luci-app-zapret/root/usr/share/rpcd/acl.d/luci-app-zapret.json
+++ b/luci-app-zapret/root/usr/share/rpcd/acl.d/luci-app-zapret.json
@@ -6,6 +6,7 @@
 			"file": {
 				"/opt/zapret/config": [ "read" ],
 				"/opt/zapret/ipset/*": [ "read" ],
+				"/opt/zapret/init.d/openwrt/custom.d/*": [ "read" ],
 				"/etc/crontabs/root": [ "read" ],
 				"/tmp/zapret*": [ "read" ],
 				"/etc/init.d/zapret*": [ "exec" ],


### PR DESCRIPTION
Fixes a behavior where files could not be read in /opt/zapret/init.d/openwrt/custom.d/*