### PR TITLE
DECL-FIX - открытие ссылки в соседней вкладке

### DIFF
--- a/luci-app-zapret/htdocs/luci-static/resources/view/zapret/settings.js
+++ b/luci-app-zapret/htdocs/luci-static/resources/view/zapret/settings.js
@@ -149,7 +149,7 @@ return view.extend({
             };
             let desc = locname;
             if (multiline == 2) {
-                desc += '<br/>' + _('Example') + ': <a href=%s>%s</a>'.format(tools.nfqws_opt_url);
+                desc += '<br/>' + _('Example') + ': <a target=_blank href=%s>%s</a>'.format(tools.nfqws_opt_url);
             }
             btn.onclick = () => new tools.longstrEditDialog('config', param, param, desc, rows, multiline).show();
         };


### PR DESCRIPTION
когда лезешь когда лезешь к люси в морду... не очень удобно что ссылка открывает в том же окне с постами стратегий и про это надо помнить... а когда ты лезешь в морду злой потому что у провайдера опять чето поменяли и у тебя опять часть сервисов хреново пашет и отваливается... надеюсь автор примет это малюсенькое замечание