### PR TITLE
fix gpg import

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
         shell: bash
         run: |
           # gpg --verbose --recv-keys 0x1D53D1877742E911
-          gpg --verbose --import <(wget -qO- 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/0x1D53D1877742E911.asc')
+          gpg --verbose --import <(wget -qO- 'https://raw.githubusercontent.com/openwrt/keyring/refs/heads/master/gpg/0x1D53D1877742E911.asc')
           # disable check signatures
           sed -i 's/gpg --/#gpg --/g' setup.sh
           # disable cleanup keys


### PR DESCRIPTION
git.openwrt.org сейчас лежит, не получается получить подпись и собрать пакет. Если поменять ссылку на github вся сборка проходит нормально. В репозитории сейчас уже используется github вместо git.openwrt.org для сборки, предлагаю убрать последнюю завязку на него.