### PR TITLE
luci: Improved display of logs.

### DIFF
--- a/luci-app-zapret/htdocs/luci-static/resources/view/zapret/dmnlog.js
+++ b/luci-app-zapret/htdocs/luci-static/resources/view/zapret/dmnlog.js
@@ -173,16 +173,16 @@ return view.extend({
             
             let tab = E('div', { 'data-tab': tabname, 'data-tab-title': tabNameText }, [
                 E('div', { 'id': 'content_dmnlog_' + log_num }, [
-                    E('div', {'style': 'padding-bottom: 20px'}, [ scrollDownButton ]),
+                    E('div', {'style': 'margin-bottom: 20px; '}, [ scrollDownButton ]),
                     E('textarea', {
                         'id': log_id,
                         'name': log_name,
-                        'style': 'font-size:12px',
+                        'style': 'font-size:12px; width: 100%; max-height: 50vh;',
                         'readonly': 'readonly',
                         'wrap': 'off',
                         'rows': logdata[log_num].rows,
                     }, [ log_text ]),
-                    E('div', {'style': 'padding-bottom: 20px'}, [ scrollUpButton ]),
+                    E('div', {'style': 'margin-top: 20px'}, [ scrollUpButton ]),
                 ]),
             ]);
             


### PR DESCRIPTION
Когда начал изучать пакет, увидел, что отображение логов сделано слегка кривовато. Решил подправить стили, теперь стало выглядеть лучше.

### Как выглядело ранее

![current_zapret_logs](https://github.com/user-attachments/assets/e23efc07-ab8a-47ab-bc80-24cbe32c3a03)

### Как выглядит с правками

![new_zapret_logs](https://github.com/user-attachments/assets/4e3ed9fd-a3c9-4155-badf-a5201c0ac7bb)

Что сделал:
1. изменил padding на margin у блоков кнопок, что логичнее.
2. у нижней кнопки смещение переместил снизу в верх
3. у основного блока сделал ширину 100% от блока родителя, а высоту 50% от размера экрана

Что не сделал:
1. Не проверил сборку, все стили прикинул в браузере через режим разработчика.
2. Не сделал автоматический скролл при обновлении логов, потому что может мешать при чтении и исследовании - интервально обновление данных может прокручивать скролл в конец, сбивая чтение в середине, начале... Нужно продумать логику и сделать красивее. 
