### PR TITLE
Update dmnlog.js

### DIFF
--- a/luci-app-zapret/htdocs/luci-static/resources/view/zapret/dmnlog.js
+++ b/luci-app-zapret/htdocs/luci-static/resources/view/zapret/dmnlog.js
@@ -5,7 +5,7 @@
 'require poll';
 'require uci';
 'require ui';
-'require view.zapret.tools as tools';
+'require view.zapret2.tools as tools';
 
 return view.extend({
     retrieveLog: async function() {


### PR DESCRIPTION
Fix HTTP error 404 while loading class file "/luci-static/resources/view/zapret/tools.js?v=25.302.55195~bfcef12" at compileClass (http://routerich.lan/luci-static/resources/luci.js?v=25.302.55195~bfcef12-1766222907:161:16) at async Promise.all (index 6)