### PR TITLE
поменять <> в v6

### DIFF
--- a/zapret/def-cfg.sh
+++ b/zapret/def-cfg.sh
@@ -261,7 +261,7 @@ function set_cfg_nfqws_strat
 				--dpi-desync-split-seqovl=1
 
 				--new
-				--filter-tcp=443 ˂HOSTLIST˃
+				--filter-tcp=443 <HOSTLIST>
 				--dpi-desync=hostfakesplit
 				--dpi-desync-hostfakesplit-mod=host=rzd.ru
 				--dpi-desync-hostfakesplit-midhost=host-2


### PR DESCRIPTION
Во всех стратегиях, кроме v6, для HOSTLIST используются обычные ASCII-скобки < >.
В v6 применены символы ˂ ˃ (Unicode), визуально похожие, но отличающиеся по коду...