### PR TITLE
Remove markdown from system information issue field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_en.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_en.yml
@@ -55,7 +55,6 @@ body:
         - **OpenWrt version**: 
         - **Zapret version**: 
         - **Router model**: 
-      render: markdown
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report_ru.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_ru.yml
@@ -55,7 +55,6 @@ body:
         - **OpenWrt версия**: 
         - **Zapret версия**: 
         - **Роутер модель**: 
-      render: markdown
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/help_wanted_en.yml
+++ b/.github/ISSUE_TEMPLATE/help_wanted_en.yml
@@ -53,7 +53,6 @@ body:
         - **OpenWrt version**: 
         - **Zapret version**: 
         - **Router model**: 
-      render: markdown
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/help_wanted_ru.yml
+++ b/.github/ISSUE_TEMPLATE/help_wanted_ru.yml
@@ -53,7 +53,6 @@ body:
         - **OpenWrt версия**: 
         - **Zapret версия**: 
         - **Роутер модель**: 
-      render: markdown
     validations:
       required: true
 


### PR DESCRIPTION
Сейчас поле System Information в формах Issue заключено в блок кода после создания Issue, несмотря на то, что в этом поле по умолчанию присутствуют разметка markdown для жирности текста.
Результат
**До:**
<img width="312" height="145" alt="image" src="https://github.com/user-attachments/assets/12b0faef-ea09-4d6f-82ce-9f2d9239de69" />

**После:**
<img width="274" height="138" alt="image" src="https://github.com/user-attachments/assets/94365157-7bbc-494f-a91a-152ef469b545" />
