### PR TITLE
fix error when packaging with Image Builder (init script) master

### DIFF
--- a/zapret2/init.d.sh
+++ b/zapret2/init.d.sh
@@ -1,6 +1,10 @@
 #!/bin/sh /etc/rc.common
 # Copyright (c) 2024 remittor
 
+# check if script is running during the image creation process (Image Builder).
+# $IPKG_INSTROOT is used by opkg, $ROOT is used by apk:
+[ -n "$IPKG_INSTROOT" ] || [ -n "$ROOT" ] && exit 0
+
 USE_PROCD=1
 # after network
 START=21


### PR DESCRIPTION
При упаковке пакета через imagebuilder возникают ошибки:
```
Finalizing root filesystem...
./imagebuilder-25.12-filogic/staging_dir/host/bin/tar: Deleting non-header from archive
./imagebuilder-25.12-filogic/staging_dir/host/bin/tar: Deleting non-header from archive
./imagebuilder-25.12-filogic/staging_dir/host/bin/tar: Deleting non-header from archive
./imagebuilder-25.12-filogic/staging_dir/host/bin/tar: Deleting non-header from archive
./imagebuilder-25.12-filogic/staging_dir/host/bin/tar: Deleting non-header from archive
add alternative: /bin/sleep -> /usr/libexec/sleep-coreutils
...
add alternative: /sbin/lsmod -> /sbin/kmodloader
add alternative: /sbin/modinfo -> /sbin/kmodloader
add alternative: /sbin/modprobe -> /sbin/kmodloader
add alternative: /usr/bin/wget -> /bin/uclient-fetch
./imagebuilder-25.12-filogic/build_dir/target-aarch64_cortex-a53_musl/root-mediatek/etc/init.d/zapret: line 10: /opt/zapret/comfunc.sh: No such file or directory
./imagebuilder-25.12-filogic/build_dir/target-aarch64_cortex-a53_musl/root-mediatek/etc/init.d/zapret: line 12: is_valid_config: command not found
```
... и образ не собирается.
Это происходит из-за того, что скрипт инициализации zapret пытается выполниться во время сборки образа (на этапе rootfs), ноне видит файлов в /opt.

Запуск init.d во время сборки, в данном случае, нам не нужен, так что настраиваем проверку в соответствии с рекомендациями: [Init scripts during compilation](https://openwrt.org/docs/guide-developer/procd-init-scripts#init_scripts_during_compilation)